### PR TITLE
Fix typo: cvs -> csv

### DIFF
--- a/docs/components/tools.md
+++ b/docs/components/tools.md
@@ -532,7 +532,7 @@ Flags:
                                 store configuration. See format details:
                                 https://thanos.io/tip/thanos/storage.md/#configuration
       --output=table            Output format for result. Currently supports
-                                table, cvs, tsv.
+                                table, csv, tsv.
   -l, --selector=<name>=\"<value>\" ...
                                 Selects blocks based on label, e.g. '-l
                                 key1=\"value1\" -l key2=\"value2\"'. All key


### PR DESCRIPTION
This fixes a typo in the documentation for the `tools` component.